### PR TITLE
feat: add twitch authentication

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/donate"
+TWITCH_CLIENT_ID=""
+TWITCH_CLIENT_SECRET=""
+NEXTAUTH_SECRET=""

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,28 @@
+import NextAuth, { NextAuthOptions } from 'next-auth'
+import TwitchProvider from 'next-auth/providers/twitch'
+import { prisma } from '../../../../lib/prisma'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    TwitchProvider({
+      clientId: process.env.TWITCH_CLIENT_ID!,
+      clientSecret: process.env.TWITCH_CLIENT_SECRET!
+    })
+  ],
+  callbacks: {
+    async signIn({ user }) {
+      if (!user.email) return false
+      await prisma.user.upsert({
+        where: { email: user.email },
+        update: { name: user.name ?? undefined },
+        create: { email: user.email, name: user.name ?? undefined }
+      })
+      return true
+    }
+  },
+  secret: process.env.NEXTAUTH_SECRET
+}
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link'
 import { getServerSession } from 'next-auth'
+import { authOptions } from './api/auth/[...nextauth]/route'
+import { SignInButton } from '../components/sign-in-button'
 import { Button } from '../components/ui/button'
 
 export default async function HomePage() {
-  const session = await getServerSession()
+  const session = await getServerSession(authOptions)
   const isAuthorized = Boolean(session)
 
   return (
@@ -15,7 +17,7 @@ export default async function HomePage() {
       ) : (
         <>
           <Button>Створити сторінку</Button>
-          <Button variant="secondary">Увійти</Button>
+          <SignInButton />
         </>
       )}
     </main>

--- a/components/sign-in-button.tsx
+++ b/components/sign-in-button.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { signIn } from 'next-auth/react'
+import { Button } from './ui/button'
+
+export interface SignInButtonProps {
+  className?: string
+}
+
+export function SignInButton({ className }: SignInButtonProps) {
+  function handleClick() {
+    signIn('twitch')
+  }
+
+  return (
+    <Button className={className} onClick={handleClick}>
+      Увійти
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add Twitch NextAuth route with DB sync
- include sign-in button on landing page
- configure env vars for Twitch OAuth

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689a31d8885c8326861f75439ecfd8a7